### PR TITLE
Add opacity setting for RECT, TEXTRECT, CRICLE, TRIANGLE, STAR, DIAMOND

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "@types/react-router": "^5.1.16",
-    "antd": "^4.16.8",
+    "antd": "^4.17.0",
     "axios": "^0.21.1",
     "base-64": "^1.0.0",
     "clipboard": "^2.0.8",

--- a/src/components/painting_content/handle_layer_click.tsx
+++ b/src/components/painting_content/handle_layer_click.tsx
@@ -4,12 +4,12 @@ const handleLayerClick = (shape: string, x: number, y: number) => {
   switch (shape) {
     case 'RECTANGLE':
       addShape({
-        width: 50, height: 50, x, y, type: 'RECTANGLE', rotation: 0, fill: '#FF6900', draggable: true,
+        width: 50, height: 50, x, y, type: 'RECTANGLE', rotation: 0, fill: '#FF6900', draggable: true, opacity: 0.9,
       });
       break;
     case 'TEXTRECT':
       addShape({
-        width: 100, height: 100, x, y, type: 'TEXTRECT', rotation: 0, fill: '#FFF9B2', draggable: true, text: '双击添加文字', fontSize: 10,
+        width: 100, height: 100, x, y, type: 'TEXTRECT', rotation: 0, fill: '#FFF9B2', draggable: true, text: '双击添加文字', fontSize: 10, opacity: 0.9,
       });
       break;
     case 'LINE':
@@ -19,12 +19,12 @@ const handleLayerClick = (shape: string, x: number, y: number) => {
       break;
     case 'CIRCLE':
       addShape({
-        radius: 30, x, y, type: 'CIRCLE', draggable: true, rotation: 0, fill: '#7BDCB5',
+        radius: 30, x, y, type: 'CIRCLE', draggable: true, rotation: 0, fill: '#7BDCB5', opacity: 0.9,
       });
       break;
     case 'TRIANGLE':
       addShape({
-        radius: { x: 30, y: 30 }, x, y, type: 'TRIANGLE', draggable: true, rotation: 0, fill: '#9900EF',
+        radius: { x: 30, y: 30 }, x, y, type: 'TRIANGLE', draggable: true, rotation: 0, fill: '#9900EF', opacity: 0.9,
       });
       break;
     case 'ELLIPSE':
@@ -34,7 +34,7 @@ const handleLayerClick = (shape: string, x: number, y: number) => {
       break;
     case 'DIAMOND':
       addShape({
-        radius: { x: 30, y: 20 }, x, y, type: 'DIAMOND', draggable: true, rotation: 0, fill: 'pink',
+        radius: { x: 30, y: 20 }, x, y, type: 'DIAMOND', draggable: true, rotation: 0, fill: 'pink', opacity: 0.9,
       });
       break;
     case 'ARROW':
@@ -49,7 +49,7 @@ const handleLayerClick = (shape: string, x: number, y: number) => {
       break;
     case 'STAR':
       addShape({
-        innerRadius: 20, outerRadius: 50, x, y, type: 'STAR', draggable: true, rotation: 0, fill: '#7BDCB5',
+        innerRadius: 20, outerRadius: 50, x, y, type: 'STAR', draggable: true, rotation: 0, fill: '#7BDCB5', opacity: 0.9,
       });
       break;
     case 'MESSAGE':

--- a/src/components/shapes/circle.tsx
+++ b/src/components/shapes/circle.tsx
@@ -45,13 +45,10 @@ const Circle: React.FC<Props> = (props: Props) => {
         onDragEnd={(e) => {
           onDragEnd();
           const afterE: BaseShapes.Circle = {
+            ...item,
             radius: e.target.attrs.radius,
             x: e.target.x(),
             y: e.target.y(),
-            type: 'CIRCLE',
-            fill: item.fill,
-            rotation: item.rotation,
-            draggable: item.draggable,
           };
           // console.log(['From: Circle Dragmove', { p: ['shapes', index], ld: doc.value.data.shapes[index], li: afterE }]);
           doc.value.submitOp([{ p: ['shapes', index], ld: doc.value.data.shapes[index], li: afterE }]);

--- a/src/components/shapes/diamond.tsx
+++ b/src/components/shapes/diamond.tsx
@@ -47,13 +47,10 @@ const Diamond: React.FC<Props> = (props: Props) => {
         onDragEnd={(e) => {
           onDragEnd();
           const afterE: BaseShapes.Diamond = {
+            ...item,
             radius: e.target.attrs.radius,
             x: e.target.x(),
             y: e.target.y(),
-            type: 'DIAMOND',
-            fill: item.fill,
-            rotation: item.rotation,
-            draggable: item.draggable,
           };
           doc.value.submitOp([{ p: ['shapes', index], ld: doc.value.data.shapes[index], li: afterE }]);
         }}
@@ -89,8 +86,6 @@ const Diamond: React.FC<Props> = (props: Props) => {
             },
             type: 'DIAMOND',
             rotation: node.rotation(),
-            fill: item.fill,
-            draggable: item.draggable,
           };
           doc.value.submitOp([{ p: ['shapes', index], ld: doc.value.data.shapes[index], li: afterE }]);
         }}

--- a/src/components/shapes/transform_rect.tsx
+++ b/src/components/shapes/transform_rect.tsx
@@ -46,14 +46,12 @@ const Rectangle1: React.FC<Props> = (props: Props) => {
         onDragEnd={(e) => {
           onDragEnd();
           const afterE: BaseShapes.Rectangle = {
+            ...item,
             width: e.target.width(),
             height: e.target.height(),
             x: e.target.x(),
             y: e.target.y(),
             draggable: true,
-            type: 'RECTANGLE',
-            rotation: item.rotation,
-            fill: item.fill,
           };
           doc.value.submitOp([{ p: ['shapes', index], ld: doc.value.data.shapes[index], li: afterE }]);
         }}

--- a/src/components/shapes/triangle.tsx
+++ b/src/components/shapes/triangle.tsx
@@ -47,13 +47,10 @@ const Triangle: React.FC<Props> = (props: Props) => {
         onDragEnd={(e) => {
           onDragEnd();
           const afterE: BaseShapes.Triangle = {
+            ...item,
             radius: e.target.attrs.radius,
             x: e.target.x(),
             y: e.target.y(),
-            type: 'TRIANGLE',
-            fill: item.fill,
-            rotation: item.rotation,
-            draggable: item.draggable,
           };
           doc.value.submitOp([{ p: ['shapes', index], ld: doc.value.data.shapes[index], li: afterE }]);
         }}
@@ -88,10 +85,7 @@ const Triangle: React.FC<Props> = (props: Props) => {
               x: Math.max(5, node.points()[0] * scaleX),
               y: Math.max(5, node.points()[3] * scaleY),
             },
-            type: 'TRIANGLE',
             rotation: node.rotation(),
-            fill: item.fill,
-            draggable: item.draggable,
           };
 
           doc.value.submitOp([{ p: ['shapes', index], ld: doc.value.data.shapes[index], li: afterE }]);

--- a/src/components/tool_bar/tools/select_color.tsx
+++ b/src/components/tool_bar/tools/select_color.tsx
@@ -2,6 +2,9 @@ import React, { useState } from 'react';
 import { Icon } from '@fluentui/react/lib/Icon';
 // @ts-ignore
 import { TwitterPicker } from 'react-color';
+import {
+  InputNumber,
+} from 'antd';
 import changeColor from '../../../utils/change_color';
 import { useDispatchStore, useStateStore } from '../../../store/store';
 import getCurrentDoc from '../../../client/client';
@@ -28,6 +31,14 @@ const SelectColor = () => {
     setClicked(false);
   };
 
+  function onChangeOpacity(value: number) {
+    const ops = state.OpList;
+    ops.push(JSON.stringify(doc.value.data.shapes));
+    dispatch({ type: 'setOpList', payload: ops });
+    const afterE: BaseShapes.Shape = { ...doc.value.data.shapes[state.currentIndex], opacity: value };
+    doc.value.submitOp([{ p: ['shapes', state.currentIndex], ld: state.currentItem, li: afterE }]);
+    dispatch({ type: 'setCurrentItem', payload: afterE });
+  }
   return (
     <div className="tool_icon">
       <Icon
@@ -35,6 +46,20 @@ const SelectColor = () => {
         onClick={() => { setClicked(true); }}
       />
       { isClicked ? <TwitterPicker color={state.currentItem.fill} onChangeComplete={handlePickComplete} /> : null}
+      { isClicked
+        ? (
+          <InputNumber
+            addonBefore="Opacity:   "
+            defaultValue={0.9}
+            min={0}
+            max={1}
+            step={0.01}
+            value={state.currentItem.opacity}
+            style={{ height: '35px', margin: '15px', width: '140px' }}
+            onChange={onChangeOpacity}
+          />
+        )
+        : null}
     </div>
   );
 };

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -15,6 +15,10 @@ namespace BaseShapes {
     text: string,
     x: number,
   }
+  interface Color{
+    fill: string,
+    opacity: number,
+  }
   interface Proj {
     text: string,
     x: number,
@@ -26,12 +30,11 @@ namespace BaseShapes {
     status: string,
     tags: Array<Tag>,
   }
-  interface Rectangle extends Position, Size, Lock {
+  interface Rectangle extends Position, Size, Lock, Color {
     type: 'RECTANGLE',
     rotation: number,
-    fill: string,
   }
-  interface Circle extends Position, Lock {
+  interface Circle extends Position, Lock, Color {
     radius: number,
     type: 'CIRCLE',
     rotation: number,
@@ -43,17 +46,15 @@ namespace BaseShapes {
     rotation: number,
     fill: string,
   }
-  interface Diamond extends Position, Lock {
+  interface Diamond extends Position, Lock, Color {
     radius: Position,
     type: 'DIAMOND',
     rotation: number,
-    fill: string,
   }
-  interface Triangle extends Position, Lock {
+  interface Triangle extends Position, Lock, Color {
     radius: Position,
     type: 'TRIANGLE',
     rotation: number,
-    fill: string,
   }
   interface Image extends Position, Size, Lock {
     type: 'IMAGE',
@@ -69,8 +70,7 @@ namespace BaseShapes {
     scaleX: number,
     shift: any,
   }
-  interface TextRect extends Position, Size, Lock {
-    fill: string;
+  interface TextRect extends Position, Size, Lock, Color {
     type: 'TEXTRECT',
     rotation: number,
     text: string,
@@ -110,9 +110,8 @@ namespace BaseShapes {
     microsoftId: string,
     mail: string
   }
-  interface Star extends Position, Lock{
+  interface Star extends Position, Lock, Color{
     type: 'STAR',
-    fill: string,
     innerRadius: number,
     outerRadius: number,
     rotation: number,


### PR DESCRIPTION
Fix #218.
Current opacity of shapes are setting to 90%, and add a setter to set opacity for RECT, TEXTRECT, CRICLE, TRIANGLE, STAR, DIAMOND.
 
![image](https://user-images.githubusercontent.com/36913755/178231558-bdfb91f1-8797-4cca-8d16-2983dc007c06.png)
![image](https://user-images.githubusercontent.com/36913755/178231624-fe2bd384-bd44-440f-8955-4e6df66e6fe1.png)
